### PR TITLE
Add scale in protection permission

### DIFF
--- a/iam_role_github_runner.tf
+++ b/iam_role_github_runner.tf
@@ -75,6 +75,7 @@ data "aws_iam_policy_document" "github_runner_basic" {
     effect = "Allow"
     actions = [
       "autoscaling:StartInstanceRefresh",
+      "autoscaling:SetInstanceProtection",
     ]
     resources = [
       aws_autoscaling_group.github_runner.arn,


### PR DESCRIPTION
Instances were being killed by autoscaling scale in. This correctly prevents runners with active jobs from being terminated.